### PR TITLE
Rewrite transactional emails

### DIFF
--- a/app/accept/mail-templates/event.pug
+++ b/app/accept/mail-templates/event.pug
@@ -1,5 +1,5 @@
 h1= __('supporter.notifyEmail.title')
-p= __('supporter.notifyEmail.intro', name, 'https://pariscall.diplomatie.fr/en/#events')
+p !{__('supporter.notifyEmail.intro', introUrl)}
 
 p= __('supporter.notifyEmail.followup')
 

--- a/app/accept/mail-templates/event.pug
+++ b/app/accept/mail-templates/event.pug
@@ -1,2 +1,6 @@
-p= __('event.notifyEmail.text', name)
+h1= __('supporter.notifyEmail.title')
+p= __('supporter.notifyEmail.intro', name, 'https://pariscall.diplomatie.fr/en/#events')
+
+p= __('supporter.notifyEmail.followup')
+
 p= __('mailSignature')

--- a/app/accept/mail-templates/supporter.pug
+++ b/app/accept/mail-templates/supporter.pug
@@ -1,3 +1,6 @@
-p= __('supporter.notifyEmail.text')
-p= __('mailSignature')
+h1= __('supporter.notifyEmail.title')
+p= __('supporter.notifyEmail.intro', 'https://pariscall.diplomatie.fr/en/supporters')
 
+p= __('supporter.notifyEmail.followup')
+
+p= __('mailSignature')

--- a/app/accept/mail-templates/supporter.pug
+++ b/app/accept/mail-templates/supporter.pug
@@ -1,5 +1,5 @@
 h1= __('supporter.notifyEmail.title')
-p= __('supporter.notifyEmail.intro', 'https://pariscall.diplomatie.fr/en/supporters')
+p !{__('supporter.notifyEmail.intro', introUrl)}
 
 p= __('supporter.notifyEmail.followup')
 

--- a/app/accept/routes.js
+++ b/app/accept/routes.js
@@ -54,7 +54,11 @@ router.get('/supporter', middlewares.tokenValidation, async (req, res, next) => 
     await mailer.sendAsAdministrator({
       to: { email: confirm_email.value },
       subject: res.__('supporter.notifyEmail.subject'),
-      content: notifySupporterEmailTemplate({ data, __: res.__ })
+      content: notifySupporterEmailTemplate({
+        data,
+        __: res.__,
+        introUrl: `${config.frontend.website}/${req.getLocale()}/supporters`
+      })
     });
 
     res.render('index', { title: `${entityName} correctement ajouté à la liste des signataires` });
@@ -107,7 +111,11 @@ router.get('/event', middlewares.tokenValidation, async (req, res, next) => {
     await mailer.sendAsAdministrator({
       to: { email: confirm_email.value },
       subject: res.__('event.notifyEmail.subject', name.value),
-      content: notifyEventEmailTemplate({ name: name.value, __: res.__ })
+      content: notifyEventEmailTemplate({
+        name: name.value,
+        __: res.__,
+        introUrl: `${config.frontend.website}/${req.getLocale()}/#events`
+      })
     });
 
     res.render('index', { title: `${entityName} correctement ajouté aux évènements` });

--- a/app/confirm-email/mail-templates/accept-event.pug
+++ b/app/confirm-email/mail-templates/accept-event.pug
@@ -11,7 +11,7 @@ ul
       br
       | #{new Date(data.date_signed).toLocaleDateString('fr-FR')} à #{new Date(data.date_signed).toLocaleTimeString('fr-FR', {hour: 'numeric', minute: 'numeric'})}
 
-p Cliquez sur le lien suivant pour approuver l'évènement' :
+p Cliquez sur le lien suivant pour approuver l'évènement :
   br
   a(href=linkUrl)
     strong Approuver

--- a/app/webhook/mail-templates/confirm-event.pug
+++ b/app/webhook/mail-templates/confirm-event.pug
@@ -1,27 +1,25 @@
 h1= __('event.confirmEmail.title')
-p= __('event.confirmEmail.intro', 'https://pariscall.diplomatie.fr/en/#events')
+p !{__('event.confirmEmail.intro', introUrl)}
 
 p= __('review')
 
 dl
   each val, index in data.formResponse
-    dt
-      data.formResponse[index].title
+    dt= data.formResponse[index].title
     dd
-      strong= #{data.formResponse[index].value}
+      strong= data.formResponse[index].value
 
 p= __('clickOnLink')
 
 h2
-  a(href=linkUrl)
-    __('event.confirmEmail.verifyButton')
+  a(href=linkUrl)= __('event.confirmEmail.verifyButton')
 
 p
-  small= __('cancel', 'https://pariscall.diplomatie.fr/en/#events')
+  small !{__('cancel', cancelUrl)}
 
-p= __('event.confirmEmail.details', 'https://pariscall.diplomatie.fr/en/supporters')
+p !{__('event.confirmEmail.details', detailsUrl)}
 
 p= __('mailSignature')
 
 p
-  small= __('linkDoesNotWork', #{linkUrl})
+  small !{__('linkDoesNotWork', linkUrl)}

--- a/app/webhook/mail-templates/confirm-event.pug
+++ b/app/webhook/mail-templates/confirm-event.pug
@@ -1,20 +1,27 @@
-p= __('event.confirmEmail.intro')
+h1= __('event.confirmEmail.title')
+p= __('event.confirmEmail.intro', 'https://pariscall.diplomatie.fr/en/#events')
 
-ul
+p= __('review')
+
+dl
   each val, index in data.formResponse
-    li
-      strong= data.formResponse[index].title
-      br
-      | #{data.formResponse[index].value}
+    dt
+      data.formResponse[index].title
+    dd
+      strong= #{data.formResponse[index].value}
 
-p= __('event.confirmEmail.clickOnLink')
-  br
+p= __('clickOnLink')
+
+h2
   a(href=linkUrl)
-    strong= __('event.confirmEmail.verifyButton')
+    __('event.confirmEmail.verifyButton')
+
+p
+  small= __('cancel', 'https://pariscall.diplomatie.fr/en/#events')
+
+p= __('event.confirmEmail.details', 'https://pariscall.diplomatie.fr/en/supporters')
 
 p= __('mailSignature')
 
-p= __('event.confirmEmail.clickOnLink')
-  small __('event.confirmEmail.linkDoesNotWork')
-    br
-    | #{linkUrl}
+p
+  small= __('linkDoesNotWork', #{linkUrl})

--- a/app/webhook/mail-templates/confirm-supporter.pug
+++ b/app/webhook/mail-templates/confirm-supporter.pug
@@ -1,27 +1,25 @@
 h1= __('supporter.confirmEmail.title')
-p= __('supporter.confirmEmail.intro', 'https://pariscall.diplomatie.fr/fr/support')
+p !{__('supporter.confirmEmail.intro', introUrl)}
 
 p= __('review')
 
 dl
   each val, index in data.formResponse
-    dt
-      data.formResponse[index].title
+    dt= data.formResponse[index].title
     dd
-      strong= #{data.formResponse[index].value}
+      strong= data.formResponse[index].value
 
 p= __('clickOnLink')
 
 h2
-  a(href=linkUrl)
-    __('supporter.confirmEmail.verifyButton')
+  a(href=linkUrl)= __('supporter.confirmEmail.verifyButton')
 
 p
-  small= __('cancel', 'https://pariscall.diplomatie.fr/fr/support')
+  small !{__('cancel', cancelUrl)}
 
-p= __('supporter.confirmEmail.details', 'https://pariscall.diplomatie.fr/fr/supporters')
+p !{__('supporter.confirmEmail.details', detailsUrl)}
 
 p= __('mailSignature')
 
 p
-  small= __('linkDoesNotWork', #{linkUrl})
+  small !{__('linkDoesNotWork', linkUrl)}

--- a/app/webhook/mail-templates/confirm-supporter.pug
+++ b/app/webhook/mail-templates/confirm-supporter.pug
@@ -1,20 +1,27 @@
-p= __('supporter.confirmEmail.intro')
+h1= __('supporter.confirmEmail.title')
+p= __('supporter.confirmEmail.intro', 'https://pariscall.diplomatie.fr/fr/support')
 
-ul
+p= __('review')
+
+dl
   each val, index in data.formResponse
-    li
-      strong= data.formResponse[index].title
-      br
-      | #{data.formResponse[index].value}
+    dt
+      data.formResponse[index].title
+    dd
+      strong= #{data.formResponse[index].value}
 
-p= __('supporter.confirmEmail.clickOnLink')
-  br
+p= __('clickOnLink')
+
+h2
   a(href=linkUrl)
-    strong= __('supporter.confirmEmail.verifyButton')
+    __('supporter.confirmEmail.verifyButton')
+
+p
+  small= __('cancel', 'https://pariscall.diplomatie.fr/fr/support')
+
+p= __('supporter.confirmEmail.details', 'https://pariscall.diplomatie.fr/fr/supporters')
 
 p= __('mailSignature')
 
 p
-  small= __('supporter.confirmEmail.linkDoesNotWork')
-    br
-    | #{linkUrl}
+  small= __('linkDoesNotWork', #{linkUrl})

--- a/app/webhook/routes.js
+++ b/app/webhook/routes.js
@@ -17,6 +17,7 @@ router.post('/supporter', async (req, res, next) => {
     mailTemplate: confirmSupporterEmailTemplate,
     linkUrl: `${config.frontend.api}/confirm-email/supporter`,
     mailSubject: res.__('supporter.confirmEmail.subject'),
+    urlSuffix: 'support',
   });
 });
 
@@ -25,6 +26,7 @@ router.post('/event', async (req, res, next) => {
     mailTemplate: confirmEventEmailTemplate,
     linkUrl: `${config.frontend.api}/confirm-email/event`,
     mailSubject: res.__('event.confirmEmail.subject'),
+    urlSuffix: '#events',
   });
 });
 
@@ -47,7 +49,14 @@ function handleWebhook(req, res, next, options) {
   const encodedData = encoder.encode(data);
 
   const linkUrl = `${options.linkUrl}?lang=${req.getLocale()}&token=${encodedData}`;
-  const mailContent = options.mailTemplate({ linkUrl, data, __: res.__ });
+  const mailContent = options.mailTemplate({
+    linkUrl,
+    data,
+    __: res.__,
+    introUrl: `${config.frontend.website}/${req.getLocale()}/${options.urlSuffix}`,
+    cancelUrl: `${config.frontend.website}/${req.getLocale()}/${options.urlSuffix}`,
+    detailsUrl: `${config.frontend.website}/${req.getLocale()}/supporters`,
+  });
 
   mailer.sendAsAdministrator({
     to: {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,29 +1,37 @@
 {
   "event": {
     "confirmEmail": {
-      "subject": "Check email",
-      "intro": "Thank you for your interest in cybersecurity Here is the information you provided:",
-      "clickOnLink": "If everything is correct, confirm your e-mail address by clicking on the link below <strong> within seven days: </ strong>",
-      "linkDoesNotWork": "The link does not work? Copy the following link into the address bar of your browser:",
-      "verifyButton": "Check email"
+      "subject": "[Paris Call] Confirm your event",
+      "title": "You suggested an event to the Paris Call",
+      "intro": "First of all, thank you for your interest in cybersecurity.<br/>Somebody, probably you or someone from your team, has filled the <a href=\"%s\">event suggestion form</a> to the Paris Call for trust and security in cyberspace. Before sending this request, we want to make sure it does come from your organisation.",
+      "verifyButton": "Suggest this event",
+      "details": "Once confirmed, your event will be reviewed before being made public. You will be notified once your event is <a href=\"%s\">publicly visible</a>."
     },
     "notifyEmail": {
-      "subject": "Event %s is approved",
-      "text": "The event %s is visible on the Paris Call website"
+      "subject": "[Paris Call] Your event is public",
+      "title": "Your event is publicly visible",
+      "intro": "You recently suggested the event “%s” to the Paris Call for trust and security in cyberspace. We are happy to inform you that this event is now <a href=\"%s\">publicly visible</a>.  Thank you for your contribution!",
+      "followup": "If you need to edit this event, please reply to this email."
     }
   },
   "supporter": {
     "confirmEmail": {
-      "subject": "Check email",
-      "intro": "Thank you for your interest in cybersecurity Here is the information you provided:",
-      "clickOnLink": "If everything is correct, confirm your e-mail address by clicking on the link below <strong> within seven days: </ strong>",
-      "linkDoesNotWork": "The link does not work? Copy the following link into the address bar of your browser:",
-      "verifyButton": "Check email"
+      "subject": "[Paris Call] Confirm your support",
+      "title": "You expressed support to the Paris Call",
+      "intro": "First of all, thank you for your interest in cybersecurity.<br/>Somebody, probably you or someone from your team, has filled the <a href=\"%s\">support form</a> to the Paris Call for trust and security in cyberspace. Before sending this request, we want to make sure it does come from your organisation.",
+      "verifyButton": "Confirm your support",
+      "details": "Once confirmed, your support is effective. There is nothing more to do. It will be reviewed before being made public. You will be notified once your support is <a href=\"%s\">publicly visible</a>.",
     },
     "notifyEmail": {
-      "subject": "Your support for the Paris Call is approved",
-      "text": "Your support is now visible on the Paris Call website"
+      "subject": "[Paris Call] Your support is public",
+      "title": "Your support is publicly visible",
+      "intro": "You recently expressed your support to the Paris Call for trust and security in cyberspace. We are happy to inform you that your support is now <a href=\"%s\">publicly visible</a>.",
+      "followup": "We will send only information specifically related to your support to this address. Updates on the Paris Call will be sent regularly to the contact address you specified when you stated your support."
     }
   },
-  "mailSignature": "The Paris Call team"
+  "review": "Please double-check the information below:",
+  "clickOnLink": "If everything is correct, confirm your request by clicking the link below within seven days:",
+  "linkDoesNotWork": "If the link does not work, copy the following address into your browser address bar: <code>%s</code>",
+  "mailSignature": "The Paris Call team",
+  "cancel": "If this request does not come from you, you don’t have anything to do. This data will not be stored if you don’t confirm the request. If you want to correct some pieces of information, please create a <a href=\"%s\">new request</a>."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -20,7 +20,7 @@
       "title": "You expressed support to the Paris Call",
       "intro": "First of all, thank you for your interest in cybersecurity.<br/>Somebody, probably you or someone from your team, has filled the <a href=\"%s\">support form</a> to the Paris Call for trust and security in cyberspace. Before sending this request, we want to make sure it does come from your organisation.",
       "verifyButton": "Confirm your support",
-      "details": "Once confirmed, your support is effective. There is nothing more to do. It will be reviewed before being made public. You will be notified once your support is <a href=\"%s\">publicly visible</a>.",
+      "details": "Once confirmed, your support is effective. There is nothing more to do. It will be reviewed before being made public. You will be notified once your support is <a href=\"%s\">publicly visible</a>."
     },
     "notifyEmail": {
       "subject": "[Paris Call] Your support is public",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,29 +1,37 @@
 {
   "event": {
     "confirmEmail": {
-      "subject": "Vérifier le courriel",
-      "intro": "Merci de votre intérêt pour la cybersécurité. Voici les informations que vous avez fournies :",
-      "clickOnLink": "Si tout est correct, confirmez votre adresse e-mail en cliquant sur le lien ci-dessous <strong>dans les sept jours :</ strong>",
-      "linkDoesNotWork": "Le lien ne fonctionne pas? Copiez le lien suivant dans la barre d'adresse de votre navigateur :",
-      "verifyButton": "Vérifier le courriel"
+      "subject": "[Appel de Paris] Confirmer votre événement",
+      "title": "Vous avez suggéré un événement pour l’Appel de Paris",
+      "intro": "Avant tout, merci de votre intérêt pour la cybersécurité.<br/>Une personne, certainement vous ou une personne de votre équipe, a rempli notre formulaire de <a href=\"%s\">proposition d’événement</a> pour le site de l'Appel de Paris pour la confiance et la sécurité dans le cyberespace. Avant d’envoyer cette suggestion, nous voulons nous assurer qu’elle provient bien de votre organisation.",
+      "verifyButton": "Proposer cet événement",
+      "details": "Une fois confirmé, votre événement sera examiné avant d’être rendu public. Vous recevrez une notification dès que votre événement sera rendu <a href=\"%s\">public</a>."
     },
     "notifyEmail": {
-      "subject": "L'évènement %s est approuvé",
-      "text": "L'événement %s est visible sur le site internet de l'Appel de Paris"
+      "subject": "[Appel de Paris] Votre événement est public",
+      "title": "Votre événement est publiquement visible",
+      "intro": "Vous avez récemment suggéré l’événement « %s » pour le site de l’Appel de Paris pour la confiance et la sécurité dans le cyberespace. Nous avons le plaisir de vous informer que votre événement est désormais <a href=\"%s\">publiquement visible</a>. Merci de votre contribution !",
+      "followup": "Si vous devez le modifier, merci de répondre à ce courriel."
     }
   },
   "supporter": {
     "confirmEmail": {
-      "subject": "Vérifier le courriel",
-      "intro": "Merci de votre intérêt pour la cybersécurité. Voici les informations que vous avez fournies :",
-      "clickOnLink": "Si tout est correct, confirmez votre adresse e-mail en cliquant sur le lien ci-dessous <strong>dans les sept jours :</ strong>",
-      "linkDoesNotWork": "Le lien ne fonctionne pas? Copiez le lien suivant dans la barre d'adresse de votre navigateur :",
-      "verifyButton": "Vérifier le courriel"
+      "subject": "[Appel de Paris] Confirmer votre soutien",
+      "title": "Vous avez exprimé un soutien à l'Appel de Paris",
+      "intro": "Avant tout, merci de votre intérêt pour la cybersécurité.<br/>Une personne, certainement vous ou une personne de votre équipe, a rempli notre <a href=\"%s\">formulaire de soutien</a> à l'Appel de Paris pour la confiance et la sécurité dans le cyberespace. Avant d’envoyer cette demande, nous voulons nous assurer qu’elle provient bien de votre organisation.",
+      "verifyButton": "Confirmer votre soutien",
+      "details": "Une fois confirmé, votre soutien est effectif. Vous n’avez rien d’autre à faire. Il sera examiné avant d’être rendu public. Vous recevrez une notification dès que votre soutien sera <a href=\"%s\">publiquement visible</a>."
     },
     "notifyEmail": {
-      "subject": "Votre soutien à l'Appel de Paris est approuvé",
-      "text": "Votre soutien est maintenant visible sur le site internet de l'Appel de Paris"
+      "subject": "[Appel de Paris] Votre soutien est public",
+      "title": "Votre soutien est publiquement visible",
+      "intro": "Vous avez récemment exprimé votre soutien à l’Appel de Paris pour la confiance et la sécurité dans le cyberespace. Nous avons le plaisir de vous informer que votre soutien est désormais <a href=\"%s\">publiquement visible</a>.",
+      "followup": "Nous n’enverrons que des informations liées spécifiquement à votre soutien à cette adresse. Les actualités de l’Appel de Paris seront envoyées régulièrement à l’adresse de contact que vous avez spécifiée lors de votre déclaration de soutien."
     }
   },
-  "mailSignature": "L'équipe de l'Appel de Paris"
+  "review": "Veuillez relire attentivement les informations ci-dessous :",
+  "clickOnLink": "Si tout est correct, confirmez votre demande en cliquant sur le lien ci-dessous dans les sept jours :",
+  "linkDoesNotWork": "Si le lien ne fonctionne pas, copiez le lien suivant dans la barre d'adresse de votre navigateur : <code>%s</code>",
+  "mailSignature": "L'équipe de l'Appel de Paris",
+  "cancel": "Si vous n’êtes pas à l'origine de cette demande, vous n’avez rien à faire. Ces données ne seront pas enregistrées si vous ne confirmez pas la demande. Si vous souhaitez modifier des éléments, effectuez une <a href=\"%s\">nouvelle demande</a>."
 }


### PR DESCRIPTION
- **I could not test PUG rendering.**
- I have made the assumption that passing multiple variables for interpolation works (in `event.pug`).
- I did not know how to interpolate passed variables, so all URLs are hardcoded for the English version of the website.
- I did not know how to interpolate passed variables, so all URLs are hardcoded for the current domain rather than use the domain env variable.
- The confirm emails templates now have exactly the same structure and differ only by their variables namespace. It might be worth merging them.